### PR TITLE
Measure execution time in python

### DIFF
--- a/python/runner.py
+++ b/python/runner.py
@@ -1,16 +1,18 @@
 import sys
+from timeit import default_timer
 
 from tarjan import TarjanAlgorithm
 
 
-def input_reader():
-    v = int(sys.stdin.readline().split(' ')[0])
-    graph = [[] for _ in range(v)]
-    for line in sys.stdin:
-        start, end = [int(e) for e in line.rsplit()]
-        graph[start].append(end)
-        graph[end].append(start)
-    return graph
+def input_reader(input_file):
+    with open(input_file, "r") as file:
+        v = int(file.readline().split(' ')[0])
+        graph = [[] for _ in range(v)]
+        for line in file:
+            start, end = [int(e) for e in line.rsplit()]
+            graph[start].append(end)
+            graph[end].append(start)
+        return graph
 
 
 def print_output(output):
@@ -20,7 +22,14 @@ def print_output(output):
 
 
 if __name__ == "__main__":
-    graph = input_reader()
+    if len(sys.argv) != 2:
+        raise Exception("Input file must be specific")
+
+    graph = input_reader(sys.argv[1])
     tarjan = TarjanAlgorithm(graph)
+
+    start = default_timer()
     tarjan.run()
-    print_output(tarjan.bridges)
+    end = default_timer()
+
+    print(int((end-start) * 1000000))  # microseconds, without fractional part

--- a/python/tarjan.py
+++ b/python/tarjan.py
@@ -1,9 +1,9 @@
 
 
 class TarjanAlgorithm(object):
-    def __init__(self, graph):
-        self._graph = graph  # adjacency list
-        self._length = len(graph)
+    def __init__(self, adjacency_list):
+        self._graph = adjacency_list
+        self._length = len(adjacency_list)
         self._bridges = []
         self.clean()
 

--- a/tests.sh
+++ b/tests.sh
@@ -2,9 +2,9 @@
 
 rm -f output.txt
 
-tarjan_algorithm_cpp=cpp/compile/cpp
-tarjan_algorithm_python=python/tarjan.py
-tarjan_algorithm_paths=($tarjan_algorithm_cpp $tarjan_algorithm_python)
+tarjan_algorithm_cpp=./cpp/compile/cpp
+tarjan_algorithm_python="python3 python/runner.py"
+tarjan_algorithm_paths=($tarjan_algorithm_cpp "$tarjan_algorithm_python")
 
 vertices=(500 1000 1500 2000 2500)
 density=(0.01 0.05 0.10 0.30 0.60)
@@ -16,7 +16,7 @@ run_all_tests_in_package() {
   iteration=$(expr $iteration + 1)
 
   for file in "$path_to_package"/*; do
-    a=$(./$current_implementation $file)
+    a=$($current_implementation $file)
     time=$(($time + $a))
   done
 


### PR DESCRIPTION
Python implementation now return execution time
in microseconds. tests.sh now can run python verison.